### PR TITLE
Added GitHub workflow to build and push docker image to GHCR

### DIFF
--- a/.github/workflows/build-and-publish-container-image.yml
+++ b/.github/workflows/build-and-publish-container-image.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ github.repository_owner }}/free_translate_api:latest
+          tags: ghcr.io/${{ github.repository_owner }}/free_translate_api:latest

--- a/.github/workflows/build-and-publish-container-image.yml
+++ b/.github/workflows/build-and-publish-container-image.yml
@@ -1,4 +1,4 @@
-name: Publish Docker image
+name: Publish Docker image to GHCR
 
 on:
   workflow_dispatch:
@@ -19,15 +19,16 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Login to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: tg3w3p/free_translate_api:latest
+          tags: ${{ github.repository_owner }}/free_translate_api:latest

--- a/.github/workflows/build-and-publish-container-image.yml
+++ b/.github/workflows/build-and-publish-container-image.yml
@@ -1,7 +1,6 @@
 name: Publish Docker image to GHCR
 
 on:
-  workflow_dispatch:
   push:
     branches: ["master"]
   pull_request:

--- a/.github/workflows/build-and-publish-container.yml
+++ b/.github/workflows/build-and-publish-container.yml
@@ -1,0 +1,33 @@
+name: Publish Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: tg3w3p/free_translate_api:latest


### PR DESCRIPTION
## Summary
This PR introduces a new GitHub workflow responsible for building the Docker image and pushing it to the GitHub container registry.

## Details
- Adds a new workflow triggered on pushes and pull requests to the `master` branch.
- The workflow logs into GHCR using the repository owner and the default `GITHUB_TOKEN`.
- Builds the Docker image from the repository root.
- Pushes the image to:
  `ghcr.io/<owner>/free_translate_api:latest`

## Purpose
This workflow automates the Docker image build and deployment process, ensuring the container is always up to date when changes are merged into `master`.

## Notes
I deployed this project on my home server, and it works great. Having an official published image will make distribution and updates even easier.